### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Microsoft code coverage tools
 
-Microsoft code coverage functionality is closed source. This repository contains documentation and samples. You can also use it to report any issues related to Microsoft.CodeCoverage nuget package, dotnet-coverage nuget package or Visual Studio code coverage functionality.
+Microsoft code coverage functionality is closed source. This repository contains documentation and samples. You can also use it to report any issues related to `Microsoft.CodeCoverage` NuGet package, `dotnet-coverage` NuGet package or Visual Studio code coverage functionality.
+
+## Documentation 
+
+* Documentation for `dotnet-coverage` tool is available at https://aka.ms/dotnet-coverage.
+* Documentation for `Microsoft.CodeCoverage` is available at https://learn.microsoft.com/visualstudio/test/customizing-code-coverage-analysis.
 
 ## Contributing
 


### PR DESCRIPTION
I keep finding myself lost trying to find the docs.

https://www.nuget.org/packages/dotnet-coverage/17.6.7 "Project website" link on the RHS points to https://aka.ms/dotnet-coverage.
https://www.nuget.org/packages/Microsoft.CodeCoverage/17.5.0 "Project website" link on the RHS points to https://github.com/microsoft/vstest/. This is confusing, and the repo's docs seem broken, and what other docs I've looked through those didn't look like geared towards consumers. But I could be wrong.

There are other docs, which look dated or kind of contradictory:
* https://learn.microsoft.com/visualstudio/test/customizing-code-coverage-analysis - this looks like it's talking about Microsoft.CodeCoverag and explinaing how to configure it. But I'm not 100% certain.
* https://learn.microsoft.com/dotnet/core/testing/unit-testing-code-coverage - this talks about coverlet.
* https://learn.microsoft.com/visualstudio/test/microsoft-code-coverage-console-tool


By all means feel free to add your changes to this branch or take over this change.